### PR TITLE
fix: enforce auth guards

### DIFF
--- a/src/polymet/data/auth-context.tsx
+++ b/src/polymet/data/auth-context.tsx
@@ -44,17 +44,6 @@ export function AuthProvider({ children }: AuthProviderProps) {
     const storedUser = localStorage.getItem("auth_user");
     if (storedUser) {
       setUser(JSON.parse(storedUser));
-    } else {
-      // For demo purposes, simulate a logged-in user
-      // In production, this would redirect to login or show a login screen
-      const mockUser: User = {
-        name: "Sarah Chen",
-        email: "sarah.chen@company.com",
-        picture: "https://github.com/yusufhilmi.png",
-        role: "admin",
-      };
-      setUser(mockUser);
-      localStorage.setItem("auth_user", JSON.stringify(mockUser));
     }
     setIsLoading(false);
   }, []);

--- a/src/polymet/pages/events-page.tsx
+++ b/src/polymet/pages/events-page.tsx
@@ -13,12 +13,9 @@ import {
 } from "lucide-react";
 import { db } from "@/polymet/data/database-service";
 import type { InterviewEvent } from "@/polymet/data/mock-interview-events-data";
+import { useAuth } from "@/polymet/data/auth-context";
 
-interface EventsPageProps {
-  userRole?: "viewer" | "talent" | "admin";
-}
-
-export function EventsPage({ userRole = "admin" }: EventsPageProps) {
+export function EventsPage() {
   const [events, setEvents] = useState<InterviewEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [markAttendanceDialogOpen, setMarkAttendanceDialogOpen] =
@@ -27,6 +24,8 @@ export function EventsPage({ userRole = "admin" }: EventsPageProps) {
   const [selectedEvent, setSelectedEvent] = useState<InterviewEvent | null>(
     null
   );
+  const { user } = useAuth();
+  const userRole = user?.role ?? "viewer";
 
   useEffect(() => {
     loadEvents();

--- a/src/polymet/pages/interviewers-page.tsx
+++ b/src/polymet/pages/interviewers-page.tsx
@@ -12,20 +12,17 @@ import {
 } from "lucide-react";
 import { db } from "@/polymet/data/database-service";
 import type { Interviewer } from "@/polymet/data/mock-interviewers-data";
+import { useAuth } from "@/polymet/data/auth-context";
 
-interface InterviewersPageProps {
-  userRole?: "viewer" | "talent" | "admin";
-}
-
-export function InterviewersPage({
-  userRole = "admin",
-}: InterviewersPageProps) {
+export function InterviewersPage() {
   const [interviewers, setInterviewers] = useState<Interviewer[]>([]);
   const [loading, setLoading] = useState(true);
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [exportDialogOpen, setExportDialogOpen] = useState(false);
   const [editingInterviewer, setEditingInterviewer] =
     useState<Interviewer | null>(null);
+  const { user } = useAuth();
+  const userRole = user?.role ?? "viewer";
 
   useEffect(() => {
     loadInterviewers();

--- a/src/polymet/pages/login-page.tsx
+++ b/src/polymet/pages/login-page.tsx
@@ -1,6 +1,6 @@
 import { useAuth } from "@/polymet/data/auth-context";
 import { GoogleSignInButton } from "@/polymet/components/google-sign-in-button";
-import { Link } from "react-router-dom";
+import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import {
   Card,
   CardContent,
@@ -12,36 +12,18 @@ import { CalendarIcon } from "lucide-react";
 
 export function LoginPage() {
   const { user, isLoading } = useAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const from =
+    (location.state as { from?: { pathname: string } } | undefined)?.from
+      ?.pathname || "/";
 
-  // If already logged in, show a message with link to dashboard
+  const handleSignInSuccess = () => {
+    navigate(from, { replace: true });
+  };
+
   if (user && !isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-background p-4">
-        <Card className="w-full max-w-md">
-          <CardHeader className="text-center space-y-4">
-            <div className="flex justify-center">
-              <div className="w-16 h-16 bg-primary rounded-lg flex items-center justify-center">
-                <CalendarIcon className="w-8 h-8 text-primary-foreground" />
-              </div>
-            </div>
-            <div>
-              <CardTitle className="text-2xl">Already Signed In</CardTitle>
-              <CardDescription className="mt-2">
-                You are already signed in as {user.name}
-              </CardDescription>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <Link
-              to="/"
-              className="inline-flex items-center justify-center w-full h-10 px-4 py-2 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-            >
-              Go to Dashboard
-            </Link>
-          </CardContent>
-        </Card>
-      </div>
-    );
+    return <Navigate to={from} replace />;
   }
 
   if (isLoading) {
@@ -72,7 +54,7 @@ export function LoginPage() {
           </div>
         </CardHeader>
         <CardContent className="space-y-4">
-          <GoogleSignInButton />
+          <GoogleSignInButton onSuccess={handleSignInSuccess} />
 
           <div className="text-center text-xs text-muted-foreground">
             By signing in, you agree to our Terms of Service and Privacy Policy


### PR DESCRIPTION
## Summary
- add login route with role-aware ProtectedRoute wrappers
- stop auto-signing users in and wire pages to real auth roles
- redirect users appropriately after login and gate admin-only pages

## Testing
- npm run lint
- npm run build