### PR TITLE
fix: auto seed mock data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,27 @@
-# React + TypeScript + Vite
+# Interviewer Roster
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Local-first interview scheduling dashboard built with React, TypeScript, and Vite.
 
-Currently, two official plugins are available:
+## Development Quickstart
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config({
-  extends: [
-    // Remove ...tseslint.configs.recommended and replace with this
-    ...tseslint.configs.recommendedTypeChecked,
-    // Alternatively, use this for stricter rules
-    ...tseslint.configs.strictTypeChecked,
-    // Optionally, add this for stylistic rules
-    ...tseslint.configs.stylisticTypeChecked,
-  ],
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+```bash
+npm ci
+npm run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+The dev server runs at http://localhost:5173. Log in with the mock Google button to explore the dashboard.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## Local Data
 
-export default tseslint.config({
-  plugins: {
-    // Add the react-x and react-dom plugins
-    'react-x': reactX,
-    'react-dom': reactDom,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended typescript rules
-    ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
-  },
-})
+- On first load the app automatically seeds mock interviewers and events into `localStorage`.
+- Use **Database → Import Mock Data** in the UI to re-seed after clearing the database or during demos.
+- Data persists per browser profile; clear the `localStorage` key `interview_roster_db` to reset manually.
+
+## Useful Scripts
+
+```bash
+npm run lint
+npm run build
 ```
+
+Linting currently surfaces a handful of warnings from generated shadcn/ui components; errors must still be resolved before merging.

--- a/src/polymet/data/database-readme.ts
+++ b/src/polymet/data/database-readme.ts
@@ -30,8 +30,8 @@
  * - Changes are immediately persisted to localStorage
  *
  * ### Initial Data:
- * - On first load, the database is seeded with mock data
- * - This provides a working demo without requiring external data
+ * - On first load, the database is seeded with mock data automatically
+ * - Re-seed at any time from the **Database → Import Mock Data** action in the app
  *
  * ## USING THE DATABASE SERVICE
  *

--- a/src/polymet/data/database-service.ts
+++ b/src/polymet/data/database-service.ts
@@ -81,15 +81,7 @@ class DatabaseService {
       const existing = localStorage.getItem(this.storageKey);
 
       if (!existing) {
-        // Create empty database (don't auto-seed)
-        // User can manually import mock data if needed
-        const emptyDb: DatabaseStorage = {
-          interviewers: [],
-          events: [],
-          auditLogs: [],
-        };
-        this.saveDatabase(emptyDb);
-        console.log("✅ Database initialized with empty state");
+        await this.seedInitialData();
       } else {
         console.log("✅ Database loaded from localStorage");
       }


### PR DESCRIPTION
## Summary
- seed the local storage database with mock interviewers/events on first run
- document the seeding behaviour and how to re-import mock data via the UI

## Testing
- npm run lint
- npm run build