### PR TITLE
fix: block empty csv exports

### DIFF
--- a/src/polymet/components/export-dialog.tsx
+++ b/src/polymet/components/export-dialog.tsx
@@ -24,7 +24,7 @@ interface ExportDialogProps {
   onExport: (type: ExportTypeOption) => void;
 }
 
-type ExportTypeOption = "interviewers" | "events" | "audit_logs";
+export type ExportTypeOption = "interviewers" | "events" | "audit_logs";
 
 export function ExportDialog({
   open,

--- a/src/polymet/pages/events-page.tsx
+++ b/src/polymet/pages/events-page.tsx
@@ -17,6 +17,7 @@ import {
   exportEventsCsv,
   exportInterviewersCsv,
 } from "@/lib/csv-utils";
+import type { ExportTypeOption } from "@/polymet/components/export-dialog";
 import type { InterviewEvent } from "@/polymet/data/mock-interview-events-data";
 import { useAuth } from "@/polymet/data/auth-context";
 
@@ -90,21 +91,33 @@ export function EventsPage() {
     }
   };
 
-  const handleExport = async (type: string) => {
+  const handleExport = async (type: ExportTypeOption) => {
     try {
       if (type === "events") {
+        if (events.length === 0) {
+          alert("No interview events available to export.");
+          return;
+        }
         exportEventsCsv(events);
         return;
       }
 
       if (type === "interviewers") {
         const roster = await db.getInterviewers();
+        if (roster.length === 0) {
+          alert("No interviewers available to export.");
+          return;
+        }
         exportInterviewersCsv(roster);
         return;
       }
 
       if (type === "audit_logs") {
         const logs = await db.getAuditLogs();
+        if (logs.length === 0) {
+          alert("No audit logs available to export.");
+          return;
+        }
         exportAuditLogsCsv(logs);
         return;
       }

--- a/src/polymet/pages/interviewers-page.tsx
+++ b/src/polymet/pages/interviewers-page.tsx
@@ -16,6 +16,7 @@ import {
   exportEventsCsv,
   exportInterviewersCsv,
 } from "@/lib/csv-utils";
+import type { ExportTypeOption } from "@/polymet/components/export-dialog";
 import type { Interviewer } from "@/polymet/data/mock-interviewers-data";
 import { useAuth } from "@/polymet/data/auth-context";
 
@@ -108,21 +109,33 @@ export function InterviewersPage() {
     }
   };
 
-  const handleExport = async (type: string) => {
+  const handleExport = async (type: ExportTypeOption) => {
     try {
       if (type === "interviewers") {
+        if (interviewers.length === 0) {
+          alert("No interviewers available to export.");
+          return;
+        }
         exportInterviewersCsv(interviewers);
         return;
       }
 
       if (type === "events") {
         const allEvents = await db.getInterviewEvents();
+        if (allEvents.length === 0) {
+          alert("No interview events available to export.");
+          return;
+        }
         exportEventsCsv(allEvents);
         return;
       }
 
       if (type === "audit_logs") {
         const logs = await db.getAuditLogs();
+        if (logs.length === 0) {
+          alert("No audit logs available to export.");
+          return;
+        }
         exportAuditLogsCsv(logs);
         return;
       }


### PR DESCRIPTION
## Summary
- prevent Interviewers, Events, and Audit Logs exports from generating CSVs when no data is available
- reuse the shared export dialog type so callers share the same contract
- surface inline alerts that explain why the download was halted

## Testing
- `npm run lint`
- manual: cleared data, confirmed export buttons show alerts instead of empty files