### PR TITLE
feat: add csv import guide

### DIFF
--- a/public/samples/audit-logs-sample.csv
+++ b/public/samples/audit-logs-sample.csv
@@ -1,0 +1,3 @@
+id,timestamp,user_name,user_email,action,entity_type,entity_id,changes
+log-demo-001,2024-03-01T12:00:00Z,Sarah Chen,sarah.chen@company.com,UPDATE_INTERVIEWER,interviewer,int-demo-002,"{""is_active"":{""from"":true,""to"":false}}"
+log-demo-002,2024-03-02T09:30:00Z,Michael Rodriguez,michael.rodriguez@company.com,CREATE_EVENT,interview_event,evt-demo-002,"{""candidate_name"":""Alex Johnson"",""position"":""Full Stack Engineer""}"

--- a/public/samples/events-sample.csv
+++ b/public/samples/events-sample.csv
@@ -1,0 +1,3 @@
+id,interviewer_email,candidate_name,position,start_time,end_time,status,skills_assessed,notes,marked_by,marked_at,created_at,updated_at,duration_minutes
+evt-demo-001,sarah.chen@company.com,Jane Smith,Frontend Developer,2024-02-15T10:00:00Z,2024-02-15T11:00:00Z,pending,"React;System Design","Initial technical screen",,,"2024-02-01T09:00:00Z","2024-02-01T09:00:00Z",60
+evt-demo-002,michael.rodriguez@company.com,Alex Johnson,Full Stack Engineer,2024-02-16T14:00:00Z,2024-02-16T15:00:00Z,attended,"Node.js;API Development","Great problem solving",michael.rodriguez@company.com,2024-02-16T16:10:00Z,"2024-02-05T08:30:00Z","2024-02-16T16:10:00Z",60

--- a/public/samples/interviewers-sample.csv
+++ b/public/samples/interviewers-sample.csv
@@ -1,0 +1,3 @@
+id,name,email,role,skills,is_active,timezone,calendar_sync_enabled,calendar_sync_consent_at,last_synced_at,created_at,updated_at,created_by,modified_at,modified_by
+int-demo-001,Sarah Chen,sarah.chen@company.com,admin,"React;TypeScript",true,America/Los_Angeles,true,2024-01-15T10:30:00Z,2024-03-20T14:22:00Z,2024-01-10T09:00:00Z,2024-03-20T14:22:00Z,system@company.com,2024-03-15T11:20:00Z,sarah.chen@company.com
+int-demo-002,Michael Rodriguez,michael.rodriguez@company.com,talent,"Node.js;API Development",true,America/New_York,true,2024-01-20T14:15:00Z,2024-03-20T13:45:00Z,2024-01-18T10:30:00Z,2024-03-10T08:05:00Z,sarah.chen@company.com,2024-03-10T08:05:00Z,michael.rodriguez@company.com


### PR DESCRIPTION
## Summary
- introduce an Import CSV Guide dialog that explains headers for interviewers, events, and audit logs before starting an import
- launch the existing CSV/JSON import flow from that dialog and keep the hidden file input for reuse
- provide downloadable sample CSVs under `public/samples/` to simplify manual testing

## Testing
- `npm run lint`
- `npm run build`
- manual: opened Import Data dialog, downloaded samples, imported each CSV/JSON and confirmed stats + audit logs updated