### PR TITLE
feat: implement admin UI for user role management (Issue #54)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ const MarkInterviewsPage = lazy(() => import("@/polymet/pages/mark-interviews-pa
 const SettingsPage = lazy(() => import("@/polymet/pages/settings-page").then(module => ({ default: module.SettingsPage })));
 const DatabaseManagementPage = lazy(() => import("@/polymet/pages/database-management-page").then(module => ({ default: module.DatabaseManagementPage })));
 const AuditLogsPage = lazy(() => import("@/polymet/pages/audit-logs-page").then(module => ({ default: module.AuditLogsPage })));
+const UserManagementPage = lazy(() => import("@/polymet/pages/user-management-page").then(module => ({ default: module.UserManagementPage })));
 const LoginPage = lazy(() => import("@/polymet/pages/login-page").then(module => ({ default: module.LoginPage })));
 
 type Role = "viewer" | "talent" | "admin";
@@ -159,6 +160,17 @@ export default function InterviewRosterApp() {
               <ProtectedRoute allowedRoles={["admin"]}>
                 <DashboardLayout>
                   <AuditLogsPage />
+                </DashboardLayout>
+              </ProtectedRoute>
+            }
+          />
+
+          <Route
+            path="/users"
+            element={
+              <ProtectedRoute allowedRoles={["admin"]}>
+                <DashboardLayout>
+                  <UserManagementPage />
                 </DashboardLayout>
               </ProtectedRoute>
             }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -58,6 +58,36 @@ const mockAuditLogs = [
   },
 ]
 
+const mockUsers = [
+  {
+    id: '1',
+    name: 'John Doe',
+    email: 'john@example.com',
+    role: 'admin',
+    picture: null,
+    last_login_at: '2024-01-15T10:30:00Z',
+    created_at: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: '2',
+    name: 'Jane Smith',
+    email: 'jane@example.com',
+    role: 'talent',
+    picture: null,
+    last_login_at: '2024-01-14T14:20:00Z',
+    created_at: '2024-01-02T00:00:00Z',
+  },
+  {
+    id: '3',
+    name: 'Bob Wilson',
+    email: 'bob@example.com',
+    role: 'viewer',
+    picture: null,
+    last_login_at: null,
+    created_at: '2024-01-03T00:00:00Z',
+  },
+]
+
 export const handlers = [
   // Auth endpoints
   http.post(`${API_URL}/api/auth/login`, async ({ request }) => {
@@ -185,6 +215,36 @@ export const handlers = [
         offset: 0,
         hasMore: false,
       },
+    })
+  }),
+
+  // Users endpoints (Issue #54)
+  http.get(`${API_URL}/api/users`, () => {
+    return HttpResponse.json({
+      users: mockUsers,
+      total: mockUsers.length,
+      hasMore: false,
+    })
+  }),
+
+  http.patch(`${API_URL}/api/users/:email/role`, async ({ params, request }) => {
+    const { email } = params
+    const body = await request.json() as { role: string }
+
+    const user = mockUsers.find(u => u.email === email)
+    if (!user) {
+      return HttpResponse.json(
+        { error: 'User not found' },
+        { status: 404 }
+      )
+    }
+
+    // Update the mock user's role
+    user.role = body.role as 'viewer' | 'talent' | 'admin'
+
+    return HttpResponse.json({
+      ...user,
+      updated_at: new Date().toISOString(),
     })
   }),
 ]

--- a/src/polymet/layouts/dashboard-layout.tsx
+++ b/src/polymet/layouts/dashboard-layout.tsx
@@ -17,6 +17,7 @@ import {
   LogOutIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  UserCogIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -85,6 +86,12 @@ export function DashboardLayout({
       href: "/audit-logs",
       icon: FileTextIcon,
       roles: ["admin"], // TA: No access
+    },
+    {
+      name: "User Management",
+      href: "/users",
+      icon: UserCogIcon,
+      roles: ["admin"], // Only admins can manage users
     },
     {
       name: "Settings",

--- a/src/polymet/pages/user-management-page.test.tsx
+++ b/src/polymet/pages/user-management-page.test.tsx
@@ -1,0 +1,420 @@
+/**
+ * User Management Page Tests (Issue #54)
+ * TDD approach for admin user role management UI
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { BrowserRouter } from 'react-router-dom'
+import { AuthProvider } from '@/polymet/data/auth-context'
+import { UserManagementPage } from './user-management-page'
+
+const renderWithAuth = (userRole: string) => {
+  // Mock localStorage with user role
+  localStorage.setItem(
+    'auth_user',
+    JSON.stringify({
+      name: 'Test User',
+      email: 'test@example.com',
+      role: userRole,
+    })
+  )
+
+  return render(
+    <BrowserRouter>
+      <AuthProvider>
+        <UserManagementPage />
+      </AuthProvider>
+    </BrowserRouter>
+  )
+}
+
+describe('Issue #54: User Management Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  describe('Access Control', () => {
+    it('should render for admin users', async () => {
+      renderWithAuth('admin')
+
+      await waitFor(() => {
+        expect(screen.getByText(/user management/i)).toBeInTheDocument()
+      })
+    })
+
+    it('should show access denied for non-admin users (viewer)', async () => {
+      renderWithAuth('viewer')
+
+      await waitFor(() => {
+        expect(screen.getByText(/access denied|unauthorized/i)).toBeInTheDocument()
+      })
+    })
+
+    it('should show access denied for talent users', async () => {
+      renderWithAuth('talent')
+
+      await waitFor(() => {
+        expect(screen.getByText(/access denied|unauthorized/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('User List Display', () => {
+    beforeEach(() => {
+      renderWithAuth('admin')
+    })
+
+    it('should display table with user information', async () => {
+      await waitFor(() => {
+        expect(screen.getByText(/user management/i)).toBeInTheDocument()
+      })
+
+      // Should have table headers
+      expect(screen.getByText(/name/i)).toBeInTheDocument()
+      expect(screen.getByText(/email/i)).toBeInTheDocument()
+      expect(screen.getByText(/role/i)).toBeInTheDocument()
+    })
+
+    it('should display users from API', async () => {
+      await waitFor(() => {
+        // Wait for mock data to load
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      expect(screen.getByText('john@example.com')).toBeInTheDocument()
+    })
+
+    it('should display role badges for each user', async () => {
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      // Should show role badges
+      const adminBadges = screen.getAllByText(/admin/i)
+      expect(adminBadges.length).toBeGreaterThan(0)
+    })
+
+    it('should display last login timestamp', async () => {
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      // Should have a last login column or timestamp
+      expect(screen.getByText(/last login/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Search and Filter', () => {
+    beforeEach(() => {
+      renderWithAuth('admin')
+    })
+
+    it('should have search input', async () => {
+      await waitFor(() => {
+        expect(screen.getByText(/user management/i)).toBeInTheDocument()
+      })
+
+      const searchInput = screen.getByPlaceholderText(/search users/i)
+      expect(searchInput).toBeInTheDocument()
+    })
+
+    it('should filter users by email', async () => {
+      const user = userEvent.setup()
+
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      const searchInput = screen.getByPlaceholderText(/search users/i)
+      await user.type(searchInput, 'john@example.com')
+
+      // Should filter results
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+    })
+
+    it('should filter users by name', async () => {
+      const user = userEvent.setup()
+
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      const searchInput = screen.getByPlaceholderText(/search users/i)
+      await user.type(searchInput, 'John')
+
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Role Management', () => {
+    beforeEach(() => {
+      renderWithAuth('admin')
+    })
+
+    it('should show role change button for each user', async () => {
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      const changeRoleButtons = screen.getAllByRole('button', { name: /change role/i })
+      expect(changeRoleButtons.length).toBeGreaterThan(0)
+    })
+
+    it('should open confirmation dialog when changing role', async () => {
+      const user = userEvent.setup()
+
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      const changeRoleButton = screen.getAllByRole('button', { name: /change role/i })[0]
+      await user.click(changeRoleButton)
+
+      // Should show dialog
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+        expect(screen.getByText(/confirm role change/i)).toBeInTheDocument()
+      })
+    })
+
+    it('should allow selecting new role in dialog', async () => {
+      const user = userEvent.setup()
+
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      const changeRoleButton = screen.getAllByRole('button', { name: /change role/i })[0]
+      await user.click(changeRoleButton)
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+
+      // Should have role selection
+      expect(screen.getByLabelText(/new role/i)).toBeInTheDocument()
+    })
+
+    it('should update user role after confirmation', async () => {
+      const user = userEvent.setup()
+
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      const changeRoleButton = screen.getAllByRole('button', { name: /change role/i })[0]
+      await user.click(changeRoleButton)
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+
+      // Select new role
+      const roleSelect = screen.getByLabelText(/new role/i)
+      await user.click(roleSelect)
+      await user.click(screen.getByText('talent'))
+
+      // Confirm
+      const confirmButton = screen.getByRole('button', { name: /confirm|save/i })
+      await user.click(confirmButton)
+
+      // Should show success message
+      await waitFor(() => {
+        expect(screen.getByText(/role updated successfully/i)).toBeInTheDocument()
+      })
+    })
+
+    it('should close dialog when canceling role change', async () => {
+      const user = userEvent.setup()
+
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      const changeRoleButton = screen.getAllByRole('button', { name: /change role/i })[0]
+      await user.click(changeRoleButton)
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+
+      const cancelButton = screen.getByRole('button', { name: /cancel/i })
+      await user.click(cancelButton)
+
+      // Dialog should close
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Error Handling', () => {
+    beforeEach(() => {
+      renderWithAuth('admin')
+    })
+
+    it('should display error message when API fails', async () => {
+      // Mock API to fail
+      const { apiClient } = await import('@/lib/api-client')
+      vi.spyOn(apiClient, 'get').mockRejectedValueOnce(new Error('API Error'))
+
+      render(
+        <BrowserRouter>
+          <AuthProvider>
+            <UserManagementPage />
+          </AuthProvider>
+        </BrowserRouter>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText(/error loading users|failed to load/i)).toBeInTheDocument()
+      })
+    })
+
+    it('should show error when role change fails', async () => {
+      const user = userEvent.setup()
+
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      // Mock role change to fail
+      const { apiClient } = await import('@/lib/api-client')
+      vi.spyOn(apiClient, 'patch').mockRejectedValueOnce(new Error('Update failed'))
+
+      const changeRoleButton = screen.getAllByRole('button', { name: /change role/i })[0]
+      await user.click(changeRoleButton)
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+
+      const roleSelect = screen.getByLabelText(/new role/i)
+      await user.click(roleSelect)
+      await user.click(screen.getByText('talent'))
+
+      const confirmButton = screen.getByRole('button', { name: /confirm|save/i })
+      await user.click(confirmButton)
+
+      // Should show error message
+      await waitFor(() => {
+        expect(screen.getByText(/failed to update role|error/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Accessibility', () => {
+    beforeEach(() => {
+      renderWithAuth('admin')
+    })
+
+    it('should have proper ARIA labels for buttons', async () => {
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      const changeRoleButtons = screen.getAllByRole('button', { name: /change role/i })
+      expect(changeRoleButtons[0]).toHaveAccessibleName()
+    })
+
+    it('should support keyboard navigation in dialog', async () => {
+      const user = userEvent.setup()
+
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      const changeRoleButton = screen.getAllByRole('button', { name: /change role/i })[0]
+      await user.click(changeRoleButton)
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+
+      // Should be able to tab through dialog elements
+      await user.keyboard('{Tab}')
+      expect(document.activeElement).toBeTruthy()
+    })
+
+    it('should trap focus within dialog', async () => {
+      const user = userEvent.setup()
+
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      const changeRoleButton = screen.getAllByRole('button', { name: /change role/i })[0]
+      await user.click(changeRoleButton)
+
+      await waitFor(() => {
+        const dialog = screen.getByRole('dialog')
+        expect(dialog).toBeInTheDocument()
+      })
+
+      // Focus should be trapped in dialog
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toBeInTheDocument()
+    })
+  })
+
+  describe('Loading States', () => {
+    it('should show loading state while fetching users', async () => {
+      renderWithAuth('admin')
+
+      // Should show loading initially
+      expect(screen.getByText(/loading/i)).toBeInTheDocument()
+    })
+
+    it('should show loading state during role change', async () => {
+      const user = userEvent.setup()
+
+      renderWithAuth('admin')
+
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+
+      const changeRoleButton = screen.getAllByRole('button', { name: /change role/i })[0]
+      await user.click(changeRoleButton)
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+
+      const roleSelect = screen.getByLabelText(/new role/i)
+      await user.click(roleSelect)
+      await user.click(screen.getByText('talent'))
+
+      const confirmButton = screen.getByRole('button', { name: /confirm|save/i })
+      await user.click(confirmButton)
+
+      // Should show loading or disabled state
+      expect(confirmButton).toBeDisabled()
+    })
+  })
+
+  describe('Empty State', () => {
+    it('should show empty state when no users exist', async () => {
+      // Mock API to return empty list
+      const { apiClient } = await import('@/lib/api-client')
+      vi.spyOn(apiClient, 'get').mockResolvedValueOnce({
+        users: [],
+        total: 0,
+        hasMore: false,
+      })
+
+      renderWithAuth('admin')
+
+      await waitFor(() => {
+        expect(screen.getByText(/no users found/i)).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/polymet/pages/user-management-page.tsx
+++ b/src/polymet/pages/user-management-page.tsx
@@ -1,0 +1,320 @@
+/**
+ * User Management Page (Issue #54)
+ * Admin-only page for managing user roles
+ */
+
+import { useState, useEffect } from 'react'
+import { useAuth } from '@/polymet/data/auth-context'
+import { apiClient } from '@/lib/api-client'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { AlertCircleIcon, CheckCircleIcon, UsersIcon } from 'lucide-react'
+
+interface User {
+  id: string
+  email: string
+  name: string
+  role: 'viewer' | 'talent' | 'admin'
+  picture?: string | null
+  last_login_at?: string | null
+  created_at: string
+}
+
+interface UsersResponse {
+  users: User[]
+  total: number
+  hasMore: boolean
+}
+
+export function UserManagementPage() {
+  const { user: currentUser } = useAuth()
+  const [users, setUsers] = useState<User[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedUser, setSelectedUser] = useState<User | null>(null)
+  const [newRole, setNewRole] = useState<'viewer' | 'talent' | 'admin'>('viewer')
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [updating, setUpdating] = useState(false)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [updateError, setUpdateError] = useState<string | null>(null)
+
+  // Check if current user is admin
+  const isAdmin = currentUser?.role === 'admin'
+
+  useEffect(() => {
+    if (isAdmin) {
+      fetchUsers()
+    }
+  }, [isAdmin])
+
+  const fetchUsers = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const response = await apiClient.get<UsersResponse>('/users')
+      setUsers(response.users)
+    } catch (err) {
+      console.error('Error fetching users:', err)
+      setError('Error loading users. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleRoleChange = (user: User) => {
+    setSelectedUser(user)
+    setNewRole(user.role)
+    setIsDialogOpen(true)
+    setUpdateError(null)
+    setSuccessMessage(null)
+  }
+
+  const handleConfirmRoleChange = async () => {
+    if (!selectedUser) return
+
+    try {
+      setUpdating(true)
+      setUpdateError(null)
+
+      await apiClient.patch(`/users/${selectedUser.email}/role`, {
+        role: newRole,
+      })
+
+      // Update local state
+      setUsers((prev) =>
+        prev.map((u) =>
+          u.email === selectedUser.email ? { ...u, role: newRole } : u
+        )
+      )
+
+      setSuccessMessage(`Role updated successfully for ${selectedUser.name}`)
+      setIsDialogOpen(false)
+      setSelectedUser(null)
+    } catch (err) {
+      console.error('Error updating role:', err)
+      setUpdateError('Failed to update role. Please try again.')
+    } finally {
+      setUpdating(false)
+    }
+  }
+
+  const handleCancelRoleChange = () => {
+    setIsDialogOpen(false)
+    setSelectedUser(null)
+    setUpdateError(null)
+  }
+
+  const filteredUsers = users.filter(
+    (user) =>
+      user.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      user.email.toLowerCase().includes(searchQuery.toLowerCase())
+  )
+
+  const getRoleBadgeVariant = (role: string) => {
+    switch (role) {
+      case 'admin':
+        return 'destructive'
+      case 'talent':
+        return 'default'
+      case 'viewer':
+        return 'secondary'
+      default:
+        return 'secondary'
+    }
+  }
+
+  const formatLastLogin = (timestamp: string | null | undefined) => {
+    if (!timestamp) return 'Never'
+    const date = new Date(timestamp)
+    return date.toLocaleString()
+  }
+
+  // Access denied for non-admin users
+  if (!isAdmin) {
+    return (
+      <div className="container mx-auto p-6">
+        <Alert variant="destructive">
+          <AlertCircleIcon className="h-4 w-4" />
+          <AlertTitle>Access Denied</AlertTitle>
+          <AlertDescription>
+            You do not have permission to access this page. Admin access is required.
+          </AlertDescription>
+        </Alert>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold mb-2 flex items-center gap-2">
+          <UsersIcon className="h-8 w-8" />
+          User Management
+        </h1>
+        <p className="text-muted-foreground">
+          Manage user roles and permissions
+        </p>
+      </div>
+
+      {/* Success Message */}
+      {successMessage && (
+        <Alert className="mb-4" variant="default">
+          <CheckCircleIcon className="h-4 w-4" />
+          <AlertTitle>Success</AlertTitle>
+          <AlertDescription>{successMessage}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Error Message */}
+      {error && (
+        <Alert className="mb-4" variant="destructive">
+          <AlertCircleIcon className="h-4 w-4" />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Search */}
+      <div className="mb-4">
+        <input
+          type="text"
+          placeholder="Search users by name or email..."
+          className="w-full px-4 py-2 border rounded-md"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          aria-label="Search users"
+        />
+      </div>
+
+      {/* Loading State */}
+      {loading && (
+        <div className="text-center py-8">
+          <p className="text-muted-foreground">Loading users...</p>
+        </div>
+      )}
+
+      {/* Empty State */}
+      {!loading && filteredUsers.length === 0 && (
+        <div className="text-center py-8">
+          <UsersIcon className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
+          <p className="text-muted-foreground">
+            {searchQuery ? 'No users found matching your search.' : 'No users found.'}
+          </p>
+        </div>
+      )}
+
+      {/* Users Table */}
+      {!loading && filteredUsers.length > 0 && (
+        <div className="border rounded-lg overflow-hidden">
+          <table className="w-full">
+            <thead className="bg-muted">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium">Name</th>
+                <th className="px-4 py-3 text-left font-medium">Email</th>
+                <th className="px-4 py-3 text-left font-medium">Role</th>
+                <th className="px-4 py-3 text-left font-medium">Last Login</th>
+                <th className="px-4 py-3 text-left font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredUsers.map((user) => (
+                <tr key={user.id} className="border-t hover:bg-muted/50">
+                  <td className="px-4 py-3">{user.name}</td>
+                  <td className="px-4 py-3">{user.email}</td>
+                  <td className="px-4 py-3">
+                    <Badge variant={getRoleBadgeVariant(user.role)}>
+                      {user.role}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-muted-foreground">
+                    {formatLastLogin(user.last_login_at)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => handleRoleChange(user)}
+                      aria-label={`Change role for ${user.name}`}
+                    >
+                      Change Role
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Role Change Dialog */}
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm Role Change</DialogTitle>
+            <DialogDescription>
+              Change the role for {selectedUser?.name} ({selectedUser?.email})
+            </DialogDescription>
+          </DialogHeader>
+
+          {updateError && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertCircleIcon className="h-4 w-4" />
+              <AlertDescription>{updateError}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="py-4">
+            <Label htmlFor="new-role">New Role</Label>
+            <Select
+              value={newRole}
+              onValueChange={(value) => setNewRole(value as 'viewer' | 'talent' | 'admin')}
+            >
+              <SelectTrigger id="new-role" aria-label="New role">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="viewer">Viewer</SelectItem>
+                <SelectItem value="talent">Talent</SelectItem>
+                <SelectItem value="admin">Admin</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={handleCancelRoleChange}
+              disabled={updating}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleConfirmRoleChange}
+              disabled={updating || newRole === selectedUser?.role}
+            >
+              {updating ? 'Updating...' : 'Confirm'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}


### PR DESCRIPTION
Part 2 of Issue #15 - Build frontend UI for admins to view and manage user roles.

## Features Implemented

### User Management Page (/users)
- Admin-only page displaying all users in a table
- Shows: name, email, role (with colored badges), last login timestamp
- Real-time search/filter by name or email
- Role badges with color coding:
  - Admin: destructive (red)
  - Talent: default (blue)
  - Viewer: secondary (gray)

### Role Management
- "Change Role" button for each user
- Confirmation dialog with role selection dropdown
- Three roles available: viewer, talent, admin
- Real-time UI updates after successful role change
- Success notifications with user feedback
- Error handling with user-friendly messages

### Access Control
- Route protected - only admins can access /users
- Non-admins see "Access Denied" message with clear explanation
- Navigation link only visible to admins in sidebar

### UI/UX Features
- Loading states during API calls
- Empty state when no users found
- Disabled state during role updates
- Search clears when input is empty
- Table shows "Never" for users who haven't logged in

### Navigation
- Added "User Management" link to dashboard sidebar
- Uses UserCogIcon from lucide-react
- Positioned between "Audit Logs" and "Settings"
- Only visible to admin role users

## Technical Implementation

### Components Created
- `src/polymet/pages/user-management-page.tsx` - Main page component
- `src/polymet/pages/user-management-page.test.tsx` - Comprehensive test suite (23 tests)

### Routes Updated
- `src/App.tsx` - Added /users route with admin-only protection
- Lazy-loaded UserManagementPage component

### MSW Handlers
- `src/mocks/handlers.ts` - Added mock users data
- GET /api/users endpoint handler
- PATCH /api/users/:email/role endpoint handler

### Accessibility
- Proper ARIA labels on all interactive elements
- Keyboard navigation support in dialogs
- Focus management in confirmation dialog
- Semantic HTML with proper heading hierarchy
- Role="alert" for error/success messages

## Testing

### Test Coverage (TDD Approach)
Created 23 tests covering:
- Access control (admin vs non-admin)
- User list display with proper data
- Search and filter functionality
- Role change workflow with confirmation
- Error handling for API failures
- Loading states
- Empty state display
- Accessibility features
- Keyboard navigation

**Note:** Tests currently use localStorage mock for auth context. Future improvement: Update test helpers to work with API-based auth.

## Dependencies
Depends on Issue #53 (backend API endpoints) - ✅ Complete

## Manual Testing
- ✅ Login with admin user (eovidiu@gmail.com)
- ✅ Navigate to User Management page
- ✅ View users in table
- ✅ Search users by name/email
- ✅ Change user role with confirmation
- ✅ See success message after update
- ✅ Non-admin users see access denied

Closes #54
Related to #15