### PR TITLE
Fix security test failures and configuration issues

### DIFF
--- a/security-tests/package.json
+++ b/security-tests/package.json
@@ -9,7 +9,7 @@
     "test:api": "node --experimental-vm-modules node_modules/jest/bin/jest.js tests/api-security.test.js",
     "test:infrastructure": "node --experimental-vm-modules node_modules/jest/bin/jest.js tests/infrastructure-security.test.js",
     "test:all": "node --experimental-vm-modules node_modules/jest/bin/jest.js --verbose",
-    "test:ci": "node --experimental-vm-modules node_modules/jest/bin/jest.js --ci --coverage --json --outputFile=reports/test-results.json",
+    "test:ci": "node --experimental-vm-modules node_modules/jest/bin/jest.js --ci --coverage --runInBand",
     "report": "node scripts/generate-report.js",
     "scan": "node scripts/security-scan.js",
     "check": "npm run test:all && npm run report"

--- a/security-tests/tests/infrastructure-security.test.js
+++ b/security-tests/tests/infrastructure-security.test.js
@@ -298,7 +298,8 @@ describe('Infrastructure Security Tests', () => {
           axios.post(`${backend}/api/auth/login`, {
             email: `test-${i}@example.com`,
             name: 'Test User'
-          }).catch(err => err.response)
+          }).then(res => ({ status: res.status }))
+            .catch(err => ({ status: err.response?.status }))
         )
       }
 

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -39,7 +39,12 @@ export async function createApp() {
 
   // Register security plugins
   await fastify.register(helmet, {
-    contentSecurityPolicy: false // Disable for Swagger UI
+    contentSecurityPolicy: false, // Disable for Swagger UI
+    hsts: {
+      maxAge: 31536000, // 1 year in seconds
+      includeSubDomains: true,
+      preload: true
+    }
   })
 
   await fastify.register(cors, config.cors)
@@ -51,6 +56,17 @@ export async function createApp() {
 
   // Register utility plugins
   await fastify.register(sensible) // Adds useful HTTP helpers
+
+  // Disable TRACE method for security
+  fastify.addHook('onRequest', async (request, reply) => {
+    if (request.method === 'TRACE') {
+      reply.code(405).send({
+        error: 'Method Not Allowed',
+        message: 'TRACE method is not allowed',
+        statusCode: 405
+      })
+    }
+  })
 
   // Register infrastructure plugins
   await fastify.register(databasePlugin)


### PR DESCRIPTION
This commit addresses multiple security test issues:

1. **Fixed Circular JSON Serialization Error**:
   - Removed `--json --outputFile` from test:ci script
   - Added `--runInBand` flag to run tests in single process
   - Modified rate limiting test to avoid keeping full response objects
   - This resolves "Converting circular structure to JSON" errors caused by HTTPS Agent objects with circular references in Jest workers

2. **Fixed HSTS Max-Age Configuration**:
   - Updated helmet configuration to set HSTS max-age to 31536000 seconds (1 year)
   - Added includeSubDomains and preload options for enhanced security
   - Previously was only 15552000 seconds (~6 months)

3. **Fixed TRACE Method Handling**:
   - Added onRequest hook to explicitly reject TRACE method with 405 status
   - Previously returned 404 instead of proper 405 Method Not Allowed
   - Improves compliance with security best practices

Files modified:
- security-tests/package.json: Updated test:ci script
- security-tests/tests/infrastructure-security.test.js: Fixed circular reference
- server/src/app.js: Added HSTS config and TRACE method handler